### PR TITLE
fix(api): use absolute API URL in production builds

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,4 +1,6 @@
-const API_BASE = '/api';
+const API_BASE = import.meta.env.PROD
+  ? `${import.meta.env.VITE_API_URL}/api`
+  : '/api';
 const FINANCE_PATH = `${API_BASE}/financeManager`;
 const AUTH_PATH = `${API_BASE}/auth`;
 const MATCHMAKING_PATH = `${API_BASE}/matchmaking`;


### PR DESCRIPTION
Production static builds have no dev-server proxy, so relative /api requests hit the frontend's own origin instead of the backend and
404. Use VITE_API_URL as an absolute base when import.meta.env.PROD.
