### PR TITLE
revert(api): keep relative /api base, rely on Render rewrite proxy

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,4 @@
-const API_BASE = import.meta.env.PROD
-  ? `${import.meta.env.VITE_API_URL}/api`
-  : '/api';
+const API_BASE = '/api';
 const FINANCE_PATH = `${API_BASE}/financeManager`;
 const AUTH_PATH = `${API_BASE}/auth`;
 const MATCHMAKING_PATH = `${API_BASE}/matchmaking`;


### PR DESCRIPTION
Switching to an absolute VITE_API_URL in production bypassed the Render static-site rewrite rule (/api/* -> backend) that the matchmaking site already has configured, turning a same-origin proxied request into a real cross-origin one and triggering CORS errors (backend has no CORS layer, and we don't want to add one). Relative /api paths let Render's rewrite proxy the request same-origin, same as the finance module already does.


Claude-Session: https://claude.ai/code/session_014812HbJ4vZVeQ4FEV9cRQq