### PR TITLE
fix(matchmaking): drop trailing slash on collection endpoints

### DIFF
--- a/src/api/hooks/useCreateMatch.ts
+++ b/src/api/hooks/useCreateMatch.ts
@@ -8,7 +8,7 @@ export function useCreateMatch() {
 
   return useMutation({
     mutationFn: async (data: CreateMatchRequest) => {
-      const response = await matchmakingRequest<Match>('/matches/', {
+      const response = await matchmakingRequest<Match>('/matches', {
         method: 'POST',
         body: JSON.stringify(data),
       });

--- a/src/api/hooks/useCreatePlayer.ts
+++ b/src/api/hooks/useCreatePlayer.ts
@@ -8,7 +8,7 @@ export function useCreatePlayer() {
 
   return useMutation({
     mutationFn: async (data: CreatePlayerRequest) => {
-      const response = await matchmakingRequest<Player>('/players/', {
+      const response = await matchmakingRequest<Player>('/players', {
         method: 'POST',
         body: JSON.stringify(data),
       });

--- a/src/api/hooks/useCreateSession.ts
+++ b/src/api/hooks/useCreateSession.ts
@@ -8,7 +8,7 @@ export function useCreateSession() {
 
   return useMutation({
     mutationFn: async (data: CreateSessionRequest) => {
-      const response = await matchmakingRequest<Session>('/sessions/', {
+      const response = await matchmakingRequest<Session>('/sessions', {
         method: 'POST',
         body: JSON.stringify(data),
       });

--- a/src/api/hooks/useCreateTeam.ts
+++ b/src/api/hooks/useCreateTeam.ts
@@ -8,7 +8,7 @@ export function useCreateTeam() {
 
   return useMutation({
     mutationFn: async (data: CreateTeamRequest) => {
-      const response = await matchmakingRequest<Team>('/teams/', {
+      const response = await matchmakingRequest<Team>('/teams', {
         method: 'POST',
         body: JSON.stringify(data),
       });

--- a/src/api/hooks/usePlayers.ts
+++ b/src/api/hooks/usePlayers.ts
@@ -7,7 +7,7 @@ export function usePlayers(enabled = true) {
   return useQuery({
     queryKey: ['matchmaking', 'players'],
     queryFn: async () => {
-      const data = await matchmakingRequest<Player[]>('/players/', {
+      const data = await matchmakingRequest<Player[]>('/players', {
         method: 'GET',
       });
 

--- a/src/api/hooks/useSessions.ts
+++ b/src/api/hooks/useSessions.ts
@@ -7,7 +7,7 @@ export function useSessions(enabled = true) {
   return useQuery({
     queryKey: ['matchmaking', 'sessions'],
     queryFn: async () => {
-      const data = await matchmakingRequest<Session[]>('/sessions/', {
+      const data = await matchmakingRequest<Session[]>('/sessions', {
         method: 'GET',
       });
 


### PR DESCRIPTION
Confirmed via direct curl against the deployed backend that /api/matchmaking/players returns 200 but /api/matchmaking/players/ (trailing slash) 404s -- same for /sessions, /teams, /matches. The matchmaking hooks were the only ones calling collection endpoints with a trailing slash; finance hooks never did, which is why only matchmaking was ever broken. CORS/proxy were both red herrings.


Claude-Session: https://claude.ai/code/session_014812HbJ4vZVeQ4FEV9cRQq